### PR TITLE
tick timer since PR not merged

### DIFF
--- a/src/WebSocketServer.php
+++ b/src/WebSocketServer.php
@@ -17,6 +17,10 @@ abstract class WebSocketServer {
   protected $headerOriginRequired                 = false;
   protected $headerSecWebSocketProtocolRequired   = false;
   protected $headerSecWebSocketExtensionsRequired = false;
+  
+  // ability to set tick() call timer in the child class
+  protected $tv_sec = 1;
+  protected $tv_usec = 0;
 
   function __construct($addr, $port, $bufferLength = 2048) {
     $this->maxBufferSize = $bufferLength;
@@ -88,7 +92,7 @@ abstract class WebSocketServer {
       $write = $except = null;
       $this->_tick();
       $this->tick();
-      @socket_select($read,$write,$except,1);
+      @socket_select($read,$write,$except, $this->tv_sec, $this->tv_usec);
       foreach ($read as $socket) {
         if ($socket == $this->master) {
           $client = socket_accept($socket);


### PR DESCRIPTION
issue 1: PHP can't find the users.php if includes are in a different folder and it caused a php fatal error (more flexible solution is an autoloader for e.g. composer)
issue 2: tick() function called once per seconds but these protected variables able to the extender class to override the tick speed even dynamically

See in original PR: https://github.com/ghedipunk/PHP-Websockets/pull/98